### PR TITLE
21 add lti key api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # LTI 1.3 Provider
 
 ## Unreleased
+- [#21](https://github.com/ibleducation/ibl-edx-lti-1p3-provider-app/issues/21): Adds API to manage `LtiToolKey`'s at a tenant level
 
 ## 2.2.0
 ### Added

--- a/src/lti_1p3_provider/api/serializers.py
+++ b/src/lti_1p3_provider/api/serializers.py
@@ -1,49 +1,55 @@
 from __future__ import annotations
 
-from typing import Any
-
+from django.db import IntegrityError
 from organizations.models import Organization
-from organizations.serializers import OrganizationSerializer
 from rest_framework import serializers
 
 from ..models import LtiKeyOrg, LtiToolKey
 from . import ssl_services
 
 
-class LtiKeyOrgSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = LtiKeyOrg
-        fields = ["org"]
-
-    org = serializers.SlugRelatedField(
-        "short_name", queryset=Organization.objects.all()
-    )
-
-
 class LtiToolKeySerializer(serializers.ModelSerializer):
     class Meta:
         model = LtiToolKey
-        fields = ["name", "private_key", "public_key", "public_jwk", "org_short_name"]
+        fields = [
+            "name",
+            "public_key",
+            "public_jwk",
+        ]
 
-    private_key = serializers.JSONField(read_only=True)
     public_key = serializers.CharField(read_only=True)
     public_jwk = serializers.JSONField(read_only=True)
-    org_short_name = serializers.SlugRelatedField(
-        "short_name", source="key_org__org", queryset=Organization.objects.all()
-    )
 
-    def validate_pviate_key(self, value: str) -> str:
+    def validate_private_key(self, value: str) -> str:
         """Check if the private key is valid"""
         if not ssl_services.is_valid_private_key(value):
             raise serializers.ValidationError("Invalid private key format")
         return value
 
+    def validate(self, attrs):
+        short_name = self.context["org_short_name"]
+        try:
+            # Since we're validating it we may as well store it
+            attrs["org"] = Organization.objects.get(short_name=short_name)
+        except Organization.DoesNotExist:
+            raise serializers.ValidationError(f"Org {short_name} Does Not Exist")
+
+        return super().validate(attrs)
+
     def create(self, validated_data):
         """Autogenerate private/public key pairs"""
+        # Since name is unique, we'll prepend the org short code to prevent collisions
+        name = validated_data["name"]
+        validated_data["name"] = f"{self.context['org_short_name']}-{name}"
+
         private_key = ssl_services.generate_private_key_pem()
         validated_data["private_key"] = private_key
         validated_data["public_key"] = ssl_services.priv_to_public_key_pem(private_key)
-        lti_org = validated_data.pop("key_org__org")
-        tool_key = LtiToolKey.objects.create(**validated_data)
-        LtiKeyOrg.objects.create(key=tool_key, org=lti_org)
+        lti_org = validated_data.pop("org")
+
+        try:
+            tool_key = LtiToolKey.objects.create(**validated_data)
+            LtiKeyOrg.objects.create(key=tool_key, org=lti_org)
+        except IntegrityError:
+            raise serializers.ValidationError(f"Tool name: '{name}' already exists")
         return tool_key

--- a/src/lti_1p3_provider/api/serializers.py
+++ b/src/lti_1p3_provider/api/serializers.py
@@ -39,6 +39,11 @@ class LtiToolKeySerializer(serializers.ModelSerializer):
         rep["name"] = rep["name"].replace(f"{org}-", "", 1)
         return rep
 
+    def update(self, instance, validated_data):
+        name = validated_data["name"]
+        validated_data["name"] = f"{self.context['org_short_name']}-{name}"
+        return super().update(instance, validated_data)
+
     def create(self, validated_data):
         """Autogenerate private/public key pairs"""
         # Since name is unique, we'll prepend the org short code to prevent collisions

--- a/src/lti_1p3_provider/api/serializers.py
+++ b/src/lti_1p3_provider/api/serializers.py
@@ -11,11 +11,7 @@ from . import ssl_services
 class LtiToolKeySerializer(serializers.ModelSerializer):
     class Meta:
         model = LtiToolKey
-        fields = [
-            "name",
-            "public_key",
-            "public_jwk",
-        ]
+        fields = ["name", "public_key", "public_jwk", "id"]
 
     public_key = serializers.CharField(read_only=True)
     public_jwk = serializers.JSONField(read_only=True)

--- a/src/lti_1p3_provider/api/serializers.py
+++ b/src/lti_1p3_provider/api/serializers.py
@@ -2,19 +2,35 @@ from __future__ import annotations
 
 from typing import Any
 
+from organizations.models import Organization
+from organizations.serializers import OrganizationSerializer
 from rest_framework import serializers
 
-from ..models import LtiKey
+from ..models import LtiKeyOrg, LtiToolKey
 from . import ssl_services
 
 
-class LtiKeySerializer(serializers.ModelSerializer):
+class LtiKeyOrgSerializer(serializers.ModelSerializer):
     class Meta:
-        model = LtiKey
-        fields = ["name", "private_key", "public_key", "public_jwk"]
+        model = LtiKeyOrg
+        fields = ["org"]
 
+    org = serializers.SlugRelatedField(
+        "short_name", queryset=Organization.objects.all()
+    )
+
+
+class LtiToolKeySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = LtiToolKey
+        fields = ["name", "private_key", "public_key", "public_jwk", "org_short_name"]
+
+    private_key = serializers.JSONField(read_only=True)
     public_key = serializers.CharField(read_only=True)
     public_jwk = serializers.JSONField(read_only=True)
+    org_short_name = serializers.SlugRelatedField(
+        "short_name", source="key_org__org", queryset=Organization.objects.all()
+    )
 
     def validate_pviate_key(self, value: str) -> str:
         """Check if the private key is valid"""
@@ -22,6 +38,12 @@ class LtiKeySerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("Invalid private key format")
         return value
 
-    def validate(self, attrs):
-        attrs["public_key"] = ssl_services.priv_to_public_key_pem(attrs["private_key"])
-        return attrs
+    def create(self, validated_data):
+        """Autogenerate private/public key pairs"""
+        private_key = ssl_services.generate_private_key_pem()
+        validated_data["private_key"] = private_key
+        validated_data["public_key"] = ssl_services.priv_to_public_key_pem(private_key)
+        lti_org = validated_data.pop("key_org__org")
+        tool_key = LtiToolKey.objects.create(**validated_data)
+        LtiKeyOrg.objects.create(key=tool_key, org=lti_org)
+        return tool_key

--- a/src/lti_1p3_provider/api/serializers.py
+++ b/src/lti_1p3_provider/api/serializers.py
@@ -28,7 +28,7 @@ class LtiToolKeySerializer(serializers.ModelSerializer):
             # Since we're validating it we may as well store it
             attrs["org"] = Organization.objects.get(short_name=short_name)
         except Organization.DoesNotExist:
-            raise serializers.ValidationError(f"Org {short_name} Does Not Exist")
+            raise serializers.ValidationError(f"Org: '{short_name}' Does Not Exist")
 
         return super().validate(attrs)
 

--- a/src/lti_1p3_provider/api/serializers.py
+++ b/src/lti_1p3_provider/api/serializers.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any
+
+from rest_framework import serializers
+
+from ..models import LtiKey
+from . import ssl_services
+
+
+class LtiKeySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = LtiKey
+        fields = ["name", "private_key", "public_key", "public_jwk"]
+
+    public_key = serializers.CharField(read_only=True)
+    public_jwk = serializers.JSONField(read_only=True)
+
+    def validate_pviate_key(self, value: str) -> str:
+        """Check if the private key is valid"""
+        if not ssl_services.is_valid_private_key(value):
+            raise serializers.ValidationError("Invalid private key format")
+        return value
+
+    def validate(self, attrs):
+        attrs["public_key"] = ssl_services.priv_to_public_key_pem(attrs["private_key"])
+        return attrs

--- a/src/lti_1p3_provider/api/serializers.py
+++ b/src/lti_1p3_provider/api/serializers.py
@@ -32,9 +32,17 @@ class LtiToolKeySerializer(serializers.ModelSerializer):
 
         return super().validate(attrs)
 
+    def to_representation(self, instance):
+        """Remove the `{org.short_name}-` prefix for name field"""
+        rep = super().to_representation(instance)
+        org = instance.key_org.org.short_name
+        rep["name"] = rep["name"].replace(f"{org}-", "", 1)
+        return rep
+
     def create(self, validated_data):
         """Autogenerate private/public key pairs"""
         # Since name is unique, we'll prepend the org short code to prevent collisions
+        # between clients
         name = validated_data["name"]
         validated_data["name"] = f"{self.context['org_short_name']}-{name}"
 

--- a/src/lti_1p3_provider/api/ssl_services.py
+++ b/src/lti_1p3_provider/api/ssl_services.py
@@ -1,0 +1,30 @@
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+
+
+def priv_to_public_key_pem(private_key: str):
+    """Return public key from private key in PEM format"""
+    private = serialization.load_pem_private_key(
+        private_key.encode("utf-8"),
+        password=None,  # Replace with the password if the private key is encrypted
+        backend=default_backend(),
+    )
+    public_key = private.public_key()
+    public_key_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return public_key_pem.decode("utf-8")
+
+
+def is_valid_private_key(private_key: str) -> bool:
+    """Return True if this is a valid private key in PEM format"""
+    try:
+        serialization.load_pem_private_key(
+            private_key.encode("utf-8"),
+            password=None,
+            backend=default_backend(),
+        )
+    except Exception:
+        return False
+    return True

--- a/src/lti_1p3_provider/api/ssl_services.py
+++ b/src/lti_1p3_provider/api/ssl_services.py
@@ -1,13 +1,34 @@
-from cryptography.hazmat.backends import default_backend
+import logging
+
 from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+log = logging.getLogger(__name__)
+
+
+def generate_private_key_pem(public_exponent=65537, key_size=2048) -> str:
+    """Generate a private key PEM
+
+    https://cryptography.io/en/latest/hazmat/primitives/asymmetric/rsa/#generation
+    """
+    private_key = rsa.generate_private_key(
+        public_exponent=public_exponent, key_size=key_size
+    )
+    return private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
 
 
 def priv_to_public_key_pem(private_key: str):
-    """Return public key from private key in PEM format"""
+    """Return public key from private key in PEM format
+
+    https://cryptography.io/en/latest/hazmat/primitives/asymmetric/rsa/#key-serialization
+    """
     private = serialization.load_pem_private_key(
         private_key.encode("utf-8"),
-        password=None,  # Replace with the password if the private key is encrypted
-        backend=default_backend(),
+        password=None,
     )
     public_key = private.public_key()
     public_key_pem = public_key.public_bytes(
@@ -23,8 +44,9 @@ def is_valid_private_key(private_key: str) -> bool:
         serialization.load_pem_private_key(
             private_key.encode("utf-8"),
             password=None,
-            backend=default_backend(),
         )
-    except Exception:
+    except Exception as e:
+        log.warning("Invalid Private Key: %s", e)
         return False
+
     return True

--- a/src/lti_1p3_provider/api/tests/test_views.py
+++ b/src/lti_1p3_provider/api/tests/test_views.py
@@ -132,3 +132,20 @@ class TestLtiKeyViews:
 
         assert LtiKeyOrg.objects.count() == 0
         assert LtiToolKey.objects.count() == 0
+
+    def test_detail_endpoint_returns_200(self, client):
+        """Detail endpoint returns entity"""
+        key_org = factories.LtiKeyOrgFactory()
+        org = key_org.org
+        key = key_org.key
+        endpoint = self._get_detail_endpoint(org.short_name, key.pk)
+
+        resp = client.get(endpoint)
+
+        assert resp.json() == {
+            "name": key.name,
+            "public_key": key.public_key,
+            "public_jwk": key.public_jwk,
+            "id": key.id,
+        }
+        assert resp.status_code == 200

--- a/src/lti_1p3_provider/api/tests/test_views.py
+++ b/src/lti_1p3_provider/api/tests/test_views.py
@@ -40,9 +40,14 @@ class TestLtiKeyViews:
         assert key_org.org == org1
 
         # Good response
+        key = key_org.key
         assert resp.status_code == 201
-        data = resp.json()
-        assert data.keys() == {"name", "public_jwk", "public_key"}
+        assert resp.json() == {
+            "public_key": key.public_key,
+            "public_jwk": key.public_jwk,
+            "name": key.name,
+            "id": key.id,
+        }
 
     def test_create_name_already_exists_in_org_returns_400(self, client):
         """Test creating a tool name that already exists in org returns 400"""
@@ -67,18 +72,21 @@ class TestLtiKeyViews:
 
         resp = client.get(endpoint)
 
-        breakpoint()
         data = resp.json()["results"]
+        key1 = key1_org1.key
+        key2 = key2_org1.key
         assert data == [
             {
-                "name": key1_org1.key.name,
-                "public_key": key1_org1.key.public_key,
-                "public_jwk": key1_org1.key.public_jwk,
+                "name": key1.name,
+                "public_key": key1.public_key,
+                "public_jwk": key1.public_jwk,
+                "id": key1.id,
             },
             {
-                "name": key2_org1.key.name,
-                "public_key": key2_org1.key.public_key,
-                "public_jwk": key2_org1.key.public_jwk,
+                "name": key2.name,
+                "public_key": key2.public_key,
+                "public_jwk": key2.public_jwk,
+                "id": key2.id,
             },
         ]
         assert resp.status_code == 200

--- a/src/lti_1p3_provider/api/tests/test_views.py
+++ b/src/lti_1p3_provider/api/tests/test_views.py
@@ -183,3 +183,5 @@ class TestLtiKeyViews:
             "id": key.id,
         }
         assert resp.status_code == 200
+        key.refresh_from_db()
+        assert key.name == f"{org.short_name}-new-name"

--- a/src/lti_1p3_provider/api/tests/test_views.py
+++ b/src/lti_1p3_provider/api/tests/test_views.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from lti_1p3_provider.api import serializers
+from lti_1p3_provider.models import LtiKeyOrg
+from lti_1p3_provider.tests import factories
+from organizations.tests.factories import OrganizationFactory
+from pylti1p3.contrib.django.lti1p3_tool_config.models import LtiTool, LtiToolKey
+
+
+@pytest.fixture(autouse=True)
+def enable_lti_1p3(settings):
+    settings.FEATURES["ENABLE_LTI_1P3_PROVIDER"] = True
+
+
+@pytest.mark.django_db
+class TestLtiKeyViews:
+    def _get_list_endpoint(self, org_short_name) -> str:
+        return reverse(
+            "lti_1p3_provider:lti-keys-list", kwargs={"org_short_name": org_short_name}
+        )
+
+    def test_create_returns_201(self, client):
+        """Test creating a key for an org returns a 201"""
+        org1 = OrganizationFactory()
+        payload = {"name": "test"}
+        endpoint = self._get_list_endpoint(org1.short_name)
+
+        resp = client.post(endpoint, data=payload)
+
+        # LtiToolKey is created
+        key = LtiToolKey.objects.get(name=f"{org1.short_name}-test")
+        assert key.private_key
+        assert key.public_key
+        assert key.public_jwk
+
+        # LtiKeyOrg is created
+        key_org = key.key_org
+        assert key_org.org == org1
+
+        # Good response
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data.keys() == {"name", "public_jwk", "public_key"}
+
+    def test_create_name_already_exists_in_org_returns_400(self, client):
+        """Test creating a tool name that already exists in org returns 400"""
+        org1 = OrganizationFactory()
+        factories.LtiToolKeyFactory(name=f"{org1.short_name}-test")
+        payload = {"name": "test"}
+        endpoint = self._get_list_endpoint(org1.short_name)
+
+        resp = client.post(endpoint, data=payload)
+
+        assert resp.json() == ["Tool name: 'test' already exists"]
+        assert resp.status_code == 400
+
+    def test_list_returns_keys_for_specified_orgs_only(self):
+        pass
+
+    def test_delete(self):
+        pass

--- a/src/lti_1p3_provider/api/tests/test_views.py
+++ b/src/lti_1p3_provider/api/tests/test_views.py
@@ -91,5 +91,16 @@ class TestLtiKeyViews:
         ]
         assert resp.status_code == 200
 
-    def test_delete(self):
+    def test_list_org_dne_returns_empty_list_with_200(self, client):
+        """If org dne, empty list is returned with 200"""
+        endpoint = self._get_list_endpoint("dne")
+
+        resp = client.get(endpoint)
+
+        data = resp.json()
+        assert data["count"] == 0
+        assert data["results"] == []
+        assert resp.status_code == 200
+
+    def test_delete(self, client):
         pass

--- a/src/lti_1p3_provider/api/tests/test_views.py
+++ b/src/lti_1p3_provider/api/tests/test_views.py
@@ -56,8 +56,32 @@ class TestLtiKeyViews:
         assert resp.json() == ["Tool name: 'test' already exists"]
         assert resp.status_code == 400
 
-    def test_list_returns_keys_for_specified_orgs_only(self):
-        pass
+    def test_list_returns_keys_for_specified_org_only(self, client):
+        key1_org1 = factories.LtiKeyOrgFactory()
+        key2_org1 = factories.LtiKeyOrgFactory(org=key1_org1.org)
+        endpoint = self._get_list_endpoint(key1_org1.org.short_name)
+
+        # These won't be returned
+        key1_org2 = factories.LtiKeyOrgFactory()
+        key2_org2 = factories.LtiKeyOrgFactory(org=key1_org2.org)
+
+        resp = client.get(endpoint)
+
+        breakpoint()
+        data = resp.json()["results"]
+        assert data == [
+            {
+                "name": key1_org1.key.name,
+                "public_key": key1_org1.key.public_key,
+                "public_jwk": key1_org1.key.public_jwk,
+            },
+            {
+                "name": key2_org1.key.name,
+                "public_key": key2_org1.key.public_key,
+                "public_jwk": key2_org1.key.public_jwk,
+            },
+        ]
+        assert resp.status_code == 200
 
     def test_delete(self):
         pass

--- a/src/lti_1p3_provider/api/tests/test_views.py
+++ b/src/lti_1p3_provider/api/tests/test_views.py
@@ -51,7 +51,7 @@ class TestLtiKeyViews:
         assert resp.json() == {
             "public_key": key.public_key,
             "public_jwk": key.public_jwk,
-            "name": key.name,
+            "name": "test",
             "id": key.id,
         }
 
@@ -79,13 +79,23 @@ class TestLtiKeyViews:
 
     def test_list_returns_keys_for_specified_org_only(self, client):
         """Test returns LtiKeys for specified org only"""
-        key1_org1 = factories.LtiKeyOrgFactory()
-        key2_org1 = factories.LtiKeyOrgFactory(org=key1_org1.org)
+        org1 = OrganizationFactory()
+        org2 = OrganizationFactory()
+        key1_org1 = factories.LtiKeyOrgFactory(
+            org=org1, key__name=f"{org1.short_name}-key-1"
+        )
+        key2_org1 = factories.LtiKeyOrgFactory(
+            org=org1, key__name=f"{org1.short_name}-key-2"
+        )
         endpoint = self._get_list_endpoint(key1_org1.org.short_name)
 
         # These won't be returned
-        key1_org2 = factories.LtiKeyOrgFactory()
-        key2_org2 = factories.LtiKeyOrgFactory(org=key1_org2.org)
+        key1_org2 = factories.LtiKeyOrgFactory(
+            org=org2, key__name=f"{org2.short_name}-key-1"
+        )
+        key2_org2 = factories.LtiKeyOrgFactory(
+            org=org2, key__name=f"{org2.short_name}-key-2"
+        )
 
         resp = client.get(endpoint)
 
@@ -94,13 +104,13 @@ class TestLtiKeyViews:
         key2 = key2_org1.key
         assert data == [
             {
-                "name": key1.name,
+                "name": "key-1",
                 "public_key": key1.public_key,
                 "public_jwk": key1.public_jwk,
                 "id": key1.id,
             },
             {
-                "name": key2.name,
+                "name": "key-2",
                 "public_key": key2.public_key,
                 "public_jwk": key2.public_jwk,
                 "id": key2.id,
@@ -135,7 +145,10 @@ class TestLtiKeyViews:
 
     def test_detail_endpoint_returns_200(self, client):
         """Detail endpoint returns entity"""
-        key_org = factories.LtiKeyOrgFactory()
+        org = OrganizationFactory()
+        key_org = factories.LtiKeyOrgFactory(
+            org=org, key__name=f"{org.short_name}-test"
+        )
         org = key_org.org
         key = key_org.key
         endpoint = self._get_detail_endpoint(org.short_name, key.pk)
@@ -143,7 +156,7 @@ class TestLtiKeyViews:
         resp = client.get(endpoint)
 
         assert resp.json() == {
-            "name": key.name,
+            "name": "test",
             "public_key": key.public_key,
             "public_jwk": key.public_jwk,
             "id": key.id,

--- a/src/lti_1p3_provider/api/urls.py
+++ b/src/lti_1p3_provider/api/urls.py
@@ -1,0 +1,6 @@
+from rest_framework.routers import DefaultRouter
+
+from .views import LtiKeyViewSet
+
+router = DefaultRouter()
+router.register("lti-keys", LtiKeyViewSet, basename="lti-keys")

--- a/src/lti_1p3_provider/api/views.py
+++ b/src/lti_1p3_provider/api/views.py
@@ -2,14 +2,19 @@ from django.utils.decorators import method_decorator
 from pylti1p3.contrib.django.lti1p3_tool_config.models import LtiToolKey
 from rest_framework.viewsets import ModelViewSet
 
+from ..models import LtiKeyOrg
 from ..views import requires_lti_enabled
-from .serializers import LtiKeySerializer
+from .serializers import LtiToolKeySerializer
 
 
 @method_decorator(requires_lti_enabled, name="dispatch")
 class LtiKeyViewSet(ModelViewSet):
-    queryset = LtiToolKey.objects.all()
-    serializer_class = LtiKeySerializer
+    serializer_class = LtiToolKeySerializer
     # FIX: get correct authentication/permission classes
     authentication_classes = []
     permission_classes = []
+
+    def get_queryset(self):
+        return LtiToolKey.objects.select_related("key_org__key").filter(
+            key_org__org__short_name=self.kwargs["org_short_name"]
+        )

--- a/src/lti_1p3_provider/api/views.py
+++ b/src/lti_1p3_provider/api/views.py
@@ -1,0 +1,15 @@
+from django.utils.decorators import method_decorator
+from pylti1p3.contrib.django.lti1p3_tool_config.models import LtiToolKey
+from rest_framework.viewsets import ModelViewSet
+
+from ..views import requires_lti_enabled
+from .serializers import LtiKeySerializer
+
+
+@method_decorator(requires_lti_enabled, name="dispatch")
+class LtiKeyViewSet(ModelViewSet):
+    queryset = LtiToolKey.objects.all()
+    serializer_class = LtiKeySerializer
+    # FIX: get correct authentication/permission classes
+    authentication_classes = []
+    permission_classes = []

--- a/src/lti_1p3_provider/api/views.py
+++ b/src/lti_1p3_provider/api/views.py
@@ -15,8 +15,10 @@ class LtiKeyViewSet(ModelViewSet):
     permission_classes = []
 
     def get_queryset(self):
-        return LtiToolKey.objects.select_related("key_org__key").filter(
-            key_org__org__short_name=self.kwargs["org_short_name"]
+        return (
+            LtiToolKey.objects.select_related("key_org__key")
+            .filter(key_org__org__short_name=self.kwargs["org_short_name"])
+            .order_by("name")
         )
 
     def get_serializer_context(self):

--- a/src/lti_1p3_provider/api/views.py
+++ b/src/lti_1p3_provider/api/views.py
@@ -1,8 +1,9 @@
 from django.utils.decorators import method_decorator
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from pylti1p3.contrib.django.lti1p3_tool_config.models import LtiToolKey
+from rest_framework.permissions import IsAdminUser
 from rest_framework.viewsets import ModelViewSet
 
-from ..models import LtiKeyOrg
 from ..views import requires_lti_enabled
 from .serializers import LtiToolKeySerializer
 
@@ -10,9 +11,8 @@ from .serializers import LtiToolKeySerializer
 @method_decorator(requires_lti_enabled, name="dispatch")
 class LtiKeyViewSet(ModelViewSet):
     serializer_class = LtiToolKeySerializer
-    # FIX: get correct authentication/permission classes
-    authentication_classes = []
-    permission_classes = []
+    authentication_classes = [BearerAuthenticationAllowInactiveUser]
+    permission_classes = [IsAdminUser]
 
     def get_queryset(self):
         return (

--- a/src/lti_1p3_provider/api/views.py
+++ b/src/lti_1p3_provider/api/views.py
@@ -18,3 +18,8 @@ class LtiKeyViewSet(ModelViewSet):
         return LtiToolKey.objects.select_related("key_org__key").filter(
             key_org__org__short_name=self.kwargs["org_short_name"]
         )
+
+    def get_serializer_context(self):
+        ctx = super().get_serializer_context()
+        ctx["org_short_name"] = self.kwargs["org_short_name"]
+        return ctx

--- a/src/lti_1p3_provider/api/views.py
+++ b/src/lti_1p3_provider/api/views.py
@@ -1,5 +1,5 @@
 from django.utils.decorators import method_decorator
-from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthentication
 from pylti1p3.contrib.django.lti1p3_tool_config.models import LtiToolKey
 from rest_framework.permissions import IsAdminUser
 from rest_framework.viewsets import ModelViewSet
@@ -11,7 +11,7 @@ from .serializers import LtiToolKeySerializer
 @method_decorator(requires_lti_enabled, name="dispatch")
 class LtiKeyViewSet(ModelViewSet):
     serializer_class = LtiToolKeySerializer
-    authentication_classes = [BearerAuthenticationAllowInactiveUser]
+    authentication_classes = [BearerAuthentication]
     permission_classes = [IsAdminUser]
 
     def get_queryset(self):

--- a/src/lti_1p3_provider/jwks.py
+++ b/src/lti_1p3_provider/jwks.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pylti1p3.contrib.django.lti1p3_tool_config.models import LtiToolKey
+from pylti1p3.registration import Registration
+
+
+def get_jwks_for_org(org_short_name: str) -> dict[str, Any]:
+    """Return JWKS filtered for specified org"""
+    keys = (
+        LtiToolKey.objects.select_related("key_org__key")
+        .filter(key_org__org__short_name=org_short_name)
+        .order_by("id")
+    )
+    jwks = []
+    public_key_lst = []
+
+    for key in keys:
+        if key.public_key and key.public_key not in public_key_lst:
+            if key.public_jwk:
+                jwks.append(json.loads(key.public_jwk))
+            else:
+                jwks.append(Registration.get_jwk(key.public_key))
+            public_key_lst.append(key.public_key)
+    return {"keys": jwks}

--- a/src/lti_1p3_provider/models.py
+++ b/src/lti_1p3_provider/models.py
@@ -60,7 +60,7 @@ from opaque_keys.edx.keys import UsageKey
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from organizations.models import Organization
 from pylti1p3.contrib.django import DjangoDbToolConf, DjangoMessageLaunch
-from pylti1p3.contrib.django.lti1p3_tool_config.models import LtiTool
+from pylti1p3.contrib.django.lti1p3_tool_config.models import LtiTool, LtiToolKey
 from pylti1p3.grade import Grade
 
 EDX_LTI_EMAIL_DOMAIN = "edx-lti-1p3.com"
@@ -397,3 +397,15 @@ class LtiToolOrg(models.Model):
 
     def __str__(self):
         return f"{self.tool.title} - {self.org}"
+
+
+class LtiKeyOrg(models.Model):
+    """Associates an LtiKey with an edx Organization"""
+
+    key = models.OneToOneField(
+        LtiToolKey, on_delete=models.CASCADE, related_name="key_org"
+    )
+    org = models.ForeignKey(Organization, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return f"{self.key.name} - {self.org.short_name}"

--- a/src/lti_1p3_provider/tests/factories.py
+++ b/src/lti_1p3_provider/tests/factories.py
@@ -17,6 +17,7 @@ from pylti1p3.registration import Registration
 from lti_1p3_provider.models import (
     LaunchGate,
     LtiGradedResource,
+    LtiKeyOrg,
     LtiProfile,
     LtiToolOrg,
 )
@@ -126,7 +127,7 @@ class LtiToolKeyFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = LtiToolKey
 
-    name = factory.Sequence(lambda n: f"Key {n}")
+    name = factory.Sequence(lambda n: f"Key-{n}")
     private_key = TOOL_PRIVATE_KEY
     public_key = TOOL_PUBLIC_KEY
 

--- a/src/lti_1p3_provider/tests/factories.py
+++ b/src/lti_1p3_provider/tests/factories.py
@@ -289,3 +289,11 @@ class LtiToolOrgFactory(factory.django.DjangoModelFactory):
 
     tool = factory.SubFactory(LtiToolFactory)
     org = factory.SubFactory(OrganizationFactory)
+
+
+class LtiKeyOrgFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = LtiKeyOrg
+
+    key = factory.SubFactory(LtiToolKeyFactory)
+    org = factory.SubFactory(OrganizationFactory)

--- a/src/lti_1p3_provider/urls.py
+++ b/src/lti_1p3_provider/urls.py
@@ -17,6 +17,11 @@ urlpatterns = [
         name="lti-display",
     ),
     path("pub/jwks/", views.LtiToolJwksView.as_view(), name="lti-pub-jwks"),
+    path(
+        "pub/orgs/<slug:org_short_name>/jwks/",
+        views.LtiOrgToolJwksView.as_view(),
+        name="lti-pub-org-jwks",
+    ),
     # API urls
     path("api/orgs/<slug:org_short_name>/", include(api_router.urls)),
 ]

--- a/src/lti_1p3_provider/urls.py
+++ b/src/lti_1p3_provider/urls.py
@@ -1,10 +1,12 @@
 """
 URL configuration for LTI 1.3 Provider
 """
+
 from django.conf import settings
-from django.urls import path, re_path
+from django.urls import include, path, re_path
 
 from . import views
+from .api.urls import router as api_router
 
 urlpatterns = [
     path("login/", views.LtiToolLoginView.as_view(), name="lti-login"),
@@ -15,4 +17,6 @@ urlpatterns = [
         name="lti-display",
     ),
     path("pub/jwks/", views.LtiToolJwksView.as_view(), name="lti-pub-jwks"),
+    # API urls
+    path("api/orgs/<slug:org_short_name>/", include(api_router.urls)),
 ]

--- a/src/lti_1p3_provider/views.py
+++ b/src/lti_1p3_provider/views.py
@@ -40,6 +40,7 @@ from pylti1p3.exception import LtiException, OIDCException
 from .error_formatter import reformat_error
 from .error_response import get_lti_error_response, render_edx_error
 from .exceptions import MissingSessionError
+from .jwks import get_jwks_for_org
 from .models import LaunchGate, LtiGradedResource, LtiProfile
 from .session_access import has_lti_session_access, set_lti_session_access
 
@@ -454,6 +455,19 @@ class LtiToolJwksView(LtiToolView):
         Return the JWKS.
         """
         return JsonResponse(self.lti_tool_config.get_jwks(), safe=False)
+
+
+class LtiOrgToolJwksView(LtiToolView):
+    """
+    JSON Web Key Sets view for a specific org
+    """
+
+    def get(self, request, org_short_name: str):
+        """
+        Return the JWKS.
+        """
+
+        return JsonResponse(get_jwks_for_org(org_short_name), safe=False)
 
 
 # This was taken from lms/djangoapps/lti_provider


### PR DESCRIPTION
* Adds API for managing `LtiToolKey`'s on a per-tenant basis
    * `lti/1p3/api/orgs/<org_short_code>/lti-keys/` endpoints 
    * Automatically creates `LtiTooLKey` associations w/ org via supplied `org_short_code`
* Works with `BeaerAuthentication` only and `IsAdminUser` permission
* Adds `lti/1p3/pub/orgs/<org_short_code>/jwks/` endpoint for org specific lti-keys

Closes #21 