### PR TITLE
22 add lti tool api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # LTI 1.3 Provider
 
 ## Unreleased
+
+## 2.3.0
 - [#21](https://github.com/ibleducation/ibl-edx-lti-1p3-provider-app/issues/21): Adds API to manage `LtiToolKey`'s at a tenant level
+- [#22](https://github.com/ibleducation/ibl-edx-lti-1p3-provider-app/issues/22): Adds API to manage `LtiTool`'s at a tenant level
 
 ## 2.2.0
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="ibl-lti-1p3-provider",
-    version="2.2.0",
+    version="2.3.0",
     packages=find_packages("src"),
     include_package_data=True,
     package_dir={"": "src"},

--- a/src/lti_1p3_provider/api/serializers.py
+++ b/src/lti_1p3_provider/api/serializers.py
@@ -76,6 +76,13 @@ class LtiToolSerializer(serializers.ModelSerializer):
 
     deployment_ids = StringListField()
 
+    def __init__(self, instance=None, data=..., **kwargs):
+        super().__init__(instance, data, **kwargs)
+        # NOTE: Restrict the tool_key querset to keys part of current org
+        self.fields["tool_key"].queryset = LtiToolKey.objects.filter(
+            key_org__org__short_name=self.context["org_short_name"]
+        )
+
     def validate(self, attrs):
         short_name = self.context["org_short_name"]
         try:

--- a/src/lti_1p3_provider/api/serializers.py
+++ b/src/lti_1p3_provider/api/serializers.py
@@ -95,11 +95,6 @@ class LtiToolSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         lti_org = validated_data.pop("org")
-        try:
-            tool = super().create(validated_data)
-        except IntegrityError:
-            raise serializers.ValidationError(
-                "Issuer and client combination already exists"
-            )
+        tool = super().create(validated_data)
         LtiToolOrg.objects.create(tool=tool, org=lti_org)
         return tool

--- a/src/lti_1p3_provider/api/serializers.py
+++ b/src/lti_1p3_provider/api/serializers.py
@@ -76,8 +76,8 @@ class LtiToolSerializer(serializers.ModelSerializer):
 
     deployment_ids = StringListField()
 
-    def __init__(self, instance=None, data=..., **kwargs):
-        super().__init__(instance, data, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         # NOTE: Restrict the tool_key querset to keys part of current org
         self.fields["tool_key"].queryset = LtiToolKey.objects.filter(
             key_org__org__short_name=self.context["org_short_name"]
@@ -91,7 +91,7 @@ class LtiToolSerializer(serializers.ModelSerializer):
         except Organization.DoesNotExist:
             raise serializers.ValidationError(f"Org: '{short_name}' Does Not Exist")
 
-        return super().validate(attrs)
+        return attrs
 
     def create(self, validated_data):
         lti_org = validated_data.pop("org")

--- a/src/lti_1p3_provider/api/ssl_services.py
+++ b/src/lti_1p3_provider/api/ssl_services.py
@@ -36,17 +36,3 @@ def priv_to_public_key_pem(private_key: str):
         format=serialization.PublicFormat.SubjectPublicKeyInfo,
     )
     return public_key_pem.decode("utf-8")
-
-
-def is_valid_private_key(private_key: str) -> bool:
-    """Return True if this is a valid private key in PEM format"""
-    try:
-        serialization.load_pem_private_key(
-            private_key.encode("utf-8"),
-            password=None,
-        )
-    except Exception as e:
-        log.warning("Invalid Private Key: %s", e)
-        return False
-
-    return True

--- a/src/lti_1p3_provider/api/tests/test_views.py
+++ b/src/lti_1p3_provider/api/tests/test_views.py
@@ -337,17 +337,23 @@ class TestLtiToolViews(BaseView):
         }
         assert resp.status_code == 400
 
-    @pytest.mark.skip
-    def test_create_name_already_exists_in_org_returns_400(self, client, admin_token):
-        """Test creating a tool name that already exists in org returns 400"""
-        org1 = OrganizationFactory()
-        factories.LtiToolKeyFactory(name=f"{org1.short_name}-test")
-        payload = {"name": "test"}
-        endpoint = self._get_list_endpoint(org1.short_name)
+    def test_create_issuer_and_client_id_already_exists_returns_400(
+        self, client, admin_token
+    ):
+        """Test creating tool if issuer/client_id already exists fails with 400"""
+        tool_org = factories.LtiToolOrgFactory()
+        tool = tool_org.tool
+        endpoint = self._get_list_endpoint(self.org.short_name)
+        self.payload["issuer"] = tool.issuer
+        self.payload["client_id"] = tool.client_id
 
-        resp = self.request(client, "post", endpoint, data=payload, token=admin_token)
+        resp = self.request(
+            client, "post", endpoint, data=self.payload, token=admin_token
+        )
 
-        assert resp.json() == ["Tool name: 'test' already exists"]
+        assert resp.json() == {
+            "non_field_errors": ["The fields issuer, client_id must make a unique set."]
+        }
         assert resp.status_code == 400
 
     @pytest.mark.skip

--- a/src/lti_1p3_provider/api/tests/test_views.py
+++ b/src/lti_1p3_provider/api/tests/test_views.py
@@ -12,7 +12,7 @@ from openedx.core.djangoapps.oauth_dispatch.tests.factories import (
     ApplicationFactory,
 )
 from organizations.tests.factories import OrganizationFactory
-from pylti1p3.contrib.django.lti1p3_tool_config.models import LtiToolKey
+from pylti1p3.contrib.django.lti1p3_tool_config.models import LtiTool, LtiToolKey
 
 
 @pytest.fixture(autouse=True)
@@ -36,19 +36,7 @@ def non_admin_token() -> str:
     yield access_token.token
 
 
-@pytest.mark.django_db
-class TestLtiKeyViews:
-    def _get_list_endpoint(self, org_short_name) -> str:
-        return reverse(
-            "lti_1p3_provider:lti-keys-list", kwargs={"org_short_name": org_short_name}
-        )
-
-    def _get_detail_endpoint(self, org_short_name, pk) -> str:
-        return reverse(
-            "lti_1p3_provider:lti-keys-detail",
-            kwargs={"org_short_name": org_short_name, "pk": pk},
-        )
-
+class BaseView:
     def request(
         self,
         client,
@@ -64,6 +52,20 @@ class TestLtiKeyViews:
             extra.pop("HTTP_AUTHORIZATION")
 
         return getattr(client, method)(endpoint, data=data, **extra)
+
+
+@pytest.mark.django_db
+class TestLtiKeyViews(BaseView):
+    def _get_list_endpoint(self, org_short_name) -> str:
+        return reverse(
+            "lti_1p3_provider:lti-keys-list", kwargs={"org_short_name": org_short_name}
+        )
+
+    def _get_detail_endpoint(self, org_short_name, pk) -> str:
+        return reverse(
+            "lti_1p3_provider:lti-keys-detail",
+            kwargs={"org_short_name": org_short_name, "pk": pk},
+        )
 
     def test_create_returns_201(self, client, admin_token):
         """Test creating a key for an org returns a 201"""
@@ -221,6 +223,225 @@ class TestLtiKeyViews:
         }
         assert resp.status_code == 200
 
+    def test_update_returns_200(self, client, admin_token):
+        """Update updates name and returns 200"""
+        org = OrganizationFactory()
+        key_org = factories.LtiKeyOrgFactory(
+            org=org, key__name=f"{org.short_name}-test"
+        )
+        org = key_org.org
+        key = key_org.key
+        endpoint = self._get_detail_endpoint(org.short_name, key.pk)
+        payload = {"name": "new-name"}
+
+        resp = self.request(client, "put", endpoint, data=payload, token=admin_token)
+
+        assert resp.json() == {
+            "name": "new-name",
+            "public_key": key.public_key,
+            "public_jwk": key.public_jwk,
+            "id": key.id,
+        }
+        assert resp.status_code == 200
+        key.refresh_from_db()
+        assert key.name == f"{org.short_name}-new-name"
+
+
+@pytest.mark.django_db
+class TestLtiToolViews(BaseView):
+    def _get_list_endpoint(self, org_short_name) -> str:
+        return reverse(
+            "lti_1p3_provider:lti-tools-list", kwargs={"org_short_name": org_short_name}
+        )
+
+    def _get_detail_endpoint(self, org_short_name, pk) -> str:
+        return reverse(
+            "lti_1p3_provider:lti-tools-detail",
+            kwargs={"org_short_name": org_short_name, "pk": pk},
+        )
+
+    def setup_method(self):
+        self.key_org = factories.LtiKeyOrgFactory()
+        self.org = self.key_org.org
+        self.key = self.key_org.key
+
+        self.payload = {
+            "title": "test",
+            "is_active": True,
+            "issuer": "https://issuer.local",
+            "client_id": "12345",
+            "use_by_default": False,
+            "auth_login_url": "https://issuer.local/auth",
+            "auth_token_url": "https://issuer.local/token",
+            "auth_audience": "",
+            "key_set_url": "https://issuer.local/keyset",
+            "key_set": "",
+            "tool_key": self.key.id,
+            "deployment_ids": [1, "test", 1234, "5"],
+        }
+
+    def test_create_returns_201(self, client, admin_token):
+        """Test creating a tool for an org returns a 201"""
+        payload = {
+            "title": "test",
+            "is_active": True,
+            "issuer": "https://issuer.local",
+            "client_id": "12345",
+            "use_by_default": False,
+            "auth_login_url": "https://issuer.local/auth",
+            "auth_token_url": "https://issuer.local/token",
+            "auth_audience": "",
+            "key_set_url": "https://issuer.local/keyset",
+            "key_set": "",
+            "tool_key": self.key.id,
+            "deployment_ids": [1, "test", 1234, "5"],
+        }
+        endpoint = self._get_list_endpoint(self.org.short_name)
+
+        resp = self.request(client, "post", endpoint, data=payload, token=admin_token)
+
+        tool = LtiTool.objects.get(client_id="12345")
+        expected = payload.copy()
+        expected["id"] = tool.id
+        expected["deployment_ids"] = [str(x) for x in payload["deployment_ids"]]
+        assert resp.json() == expected
+        assert tool.tool_org.org == self.org
+
+    @pytest.mark.skip
+    def test_create_org_dne_returns_400(self, client, admin_token):
+        """Test creating key for org that DNE returns 400"""
+        endpoint = self._get_list_endpoint("dne")
+
+        resp = self.request(client, "post", endpoint, data=payload, token=admin_token)
+
+        assert resp.json() == {"non_field_errors": ["Org: 'dne' Does Not Exist"]}
+        assert resp.status_code == 400
+
+    @pytest.mark.skip
+    def test_create_name_already_exists_in_org_returns_400(self, client, admin_token):
+        """Test creating a tool name that already exists in org returns 400"""
+        org1 = OrganizationFactory()
+        factories.LtiToolKeyFactory(name=f"{org1.short_name}-test")
+        payload = {"name": "test"}
+        endpoint = self._get_list_endpoint(org1.short_name)
+
+        resp = self.request(client, "post", endpoint, data=payload, token=admin_token)
+
+        assert resp.json() == ["Tool name: 'test' already exists"]
+        assert resp.status_code == 400
+
+    @pytest.mark.skip
+    def test_create_same_name_in_multiple_orgs_succeeds_200(self, client, admin_token):
+        """Multiple orgs can create tokens with the same name from their perspective"""
+        org1 = OrganizationFactory()
+        org2 = OrganizationFactory()
+        payload = {"name": "test"}
+        endpoint1 = self._get_list_endpoint(org1.short_name)
+        endpoint2 = self._get_list_endpoint(org2.short_name)
+
+        resp1 = self.request(client, "post", endpoint1, data=payload, token=admin_token)
+        resp2 = self.request(client, "post", endpoint2, data=payload, token=admin_token)
+
+        assert resp1.status_code == 201
+        assert resp2.status_code == 201
+
+        key1 = LtiKeyOrg.objects.get(org=org1).key
+        assert key1.name == f"{org1.short_name}-test"
+        key2 = LtiKeyOrg.objects.get(org=org2).key
+        assert key2.name == f"{org2.short_name}-test"
+
+    @pytest.mark.skip
+    def test_list_returns_keys_for_specified_org_only(self, client, admin_token):
+        """Test returns LtiKeys for specified org only"""
+        org1 = OrganizationFactory()
+        org2 = OrganizationFactory()
+        key1_org1 = factories.LtiKeyOrgFactory(
+            org=org1, key__name=f"{org1.short_name}-key-1"
+        )
+        key2_org1 = factories.LtiKeyOrgFactory(
+            org=org1, key__name=f"{org1.short_name}-key-2"
+        )
+        endpoint = self._get_list_endpoint(key1_org1.org.short_name)
+
+        # These won't be returned
+        key1_org2 = factories.LtiKeyOrgFactory(
+            org=org2, key__name=f"{org2.short_name}-key-1"
+        )
+        key2_org2 = factories.LtiKeyOrgFactory(
+            org=org2, key__name=f"{org2.short_name}-key-2"
+        )
+
+        resp = self.request(client, "get", endpoint, token=admin_token)
+
+        data = resp.json()["results"]
+
+        key1 = key1_org1.key
+        key2 = key2_org1.key
+        assert data == [
+            {
+                "name": "key-1",
+                "public_key": key1.public_key,
+                "public_jwk": key1.public_jwk,
+                "id": key1.id,
+            },
+            {
+                "name": "key-2",
+                "public_key": key2.public_key,
+                "public_jwk": key2.public_jwk,
+                "id": key2.id,
+            },
+        ]
+        assert resp.status_code == 200
+
+    @pytest.mark.skip
+    def test_list_org_dne_returns_empty_list_with_200(self, client, admin_token):
+        """If org dne, empty list is returned with 200"""
+        endpoint = self._get_list_endpoint("dne")
+
+        resp = self.request(client, "get", endpoint, token=admin_token)
+
+        data = resp.json()
+        assert data["count"] == 0
+        assert data["results"] == []
+        assert resp.status_code == 200
+
+    @pytest.mark.skip
+    def test_delete_returns_204(self, client, admin_token):
+        """Delete removes LtiToolKey and LtiKeyOrg for specified enttiy, returns 204"""
+        key_org = factories.LtiKeyOrgFactory()
+        org = key_org.org
+        key = key_org.key
+        endpoint = self._get_detail_endpoint(org.short_name, key.pk)
+
+        resp = self.request(client, "delete", endpoint, token=admin_token)
+
+        assert resp.status_code == 204
+
+        assert LtiKeyOrg.objects.count() == 0
+        assert LtiToolKey.objects.count() == 0
+
+    @pytest.mark.skip
+    def test_detail_returns_200(self, client, admin_token):
+        """Detail endpoint returns entity"""
+        org = OrganizationFactory()
+        key_org = factories.LtiKeyOrgFactory(
+            org=org, key__name=f"{org.short_name}-test"
+        )
+        org = key_org.org
+        key = key_org.key
+        endpoint = self._get_detail_endpoint(org.short_name, key.pk)
+
+        resp = self.request(client, "get", endpoint, token=admin_token)
+
+        assert resp.json() == {
+            "name": "test",
+            "public_key": key.public_key,
+            "public_jwk": key.public_jwk,
+            "id": key.id,
+        }
+        assert resp.status_code == 200
+
+    @pytest.mark.skip
     def test_update_returns_200(self, client, admin_token):
         """Update updates name and returns 200"""
         org = OrganizationFactory()

--- a/src/lti_1p3_provider/api/urls.py
+++ b/src/lti_1p3_provider/api/urls.py
@@ -1,6 +1,7 @@
 from rest_framework.routers import DefaultRouter
 
-from .views import LtiKeyViewSet
+from .views import LtiKeyViewSet, LtiToolViewSet
 
 router = DefaultRouter()
 router.register("lti-keys", LtiKeyViewSet, basename="lti-keys")
+router.register("lti-tools", LtiToolViewSet, basename="lti-tools")

--- a/src/lti_1p3_provider/api/views.py
+++ b/src/lti_1p3_provider/api/views.py
@@ -5,7 +5,7 @@ from rest_framework.permissions import IsAdminUser
 from rest_framework.viewsets import ModelViewSet
 
 from ..views import requires_lti_enabled
-from .serializers import LtiToolKeySerializer
+from .serializers import LtiToolKeySerializer, LtiToolSerializer
 
 
 @method_decorator(requires_lti_enabled, name="dispatch")
@@ -18,6 +18,25 @@ class LtiKeyViewSet(ModelViewSet):
         return (
             LtiToolKey.objects.select_related("key_org__key")
             .filter(key_org__org__short_name=self.kwargs["org_short_name"])
+            .order_by("name")
+        )
+
+    def get_serializer_context(self):
+        ctx = super().get_serializer_context()
+        ctx["org_short_name"] = self.kwargs["org_short_name"]
+        return ctx
+
+
+@method_decorator(requires_lti_enabled, name="dispatch")
+class LtiToolViewSet(ModelViewSet):
+    serializer_class = LtiToolSerializer
+    authentication_classes = [BearerAuthentication]
+    permission_classes = [IsAdminUser]
+
+    def get_queryset(self):
+        return (
+            LtiToolKey.objects.select_related("tool_org__tool")
+            .filter(tool_org__org__short_name=self.kwargs["org_short_name"])
             .order_by("name")
         )
 

--- a/src/lti_1p3_provider/api/views.py
+++ b/src/lti_1p3_provider/api/views.py
@@ -1,6 +1,6 @@
 from django.utils.decorators import method_decorator
 from openedx.core.lib.api.authentication import BearerAuthentication
-from pylti1p3.contrib.django.lti1p3_tool_config.models import LtiToolKey
+from pylti1p3.contrib.django.lti1p3_tool_config.models import LtiTool, LtiToolKey
 from rest_framework.permissions import IsAdminUser
 from rest_framework.viewsets import ModelViewSet
 
@@ -35,9 +35,9 @@ class LtiToolViewSet(ModelViewSet):
 
     def get_queryset(self):
         return (
-            LtiToolKey.objects.select_related("tool_org__tool")
+            LtiTool.objects.select_related("tool_org__tool")
             .filter(tool_org__org__short_name=self.kwargs["org_short_name"])
-            .order_by("name")
+            .order_by("title")
         )
 
     def get_serializer_context(self):


### PR DESCRIPTION
* Adds API to manage `LtiTool`'s at a tenant level
    * `lti/1p3/api/orgs/<org_short_code>/lti-tools/*`
    * Creates associations between `LtiTool` and target `organization`
* Uses `BearerAuthentication` and `IsAdminUser` permissions
* Bumps version to `2.3.0`

Closes #22 