### PR TITLE
30 store first and last name if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 2.3.2
+### Changed
+- [#30](https://github.com/ibleducation/ibl-edx-lti-1p3-provider-app/issues/30): Store `given_name` and `family_name` claims on `User` object if present
+    - Stored on `User.first_name` and `User.last_name`, respectively
+
 ## 2.3.1
 ### Changed
 - [#28](https://github.com/ibleducation/ibl-edx-lti-1p3-provider-app/issues/28): Stores JWT email claim in `UserProfile.meta` and `LtiProfile.email` if present

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="ibl-lti-1p3-provider",
-    version="2.3.1",
+    version="2.3.2",
     packages=find_packages("src"),
     include_package_data=True,
     package_dir={"": "src"},

--- a/src/lti_1p3_provider/models.py
+++ b/src/lti_1p3_provider/models.py
@@ -82,6 +82,7 @@ def create_edx_user(first_name: str, last_name: str) -> tuple[User, bool]:
     # LTI users can only auth throught LTI launches.
     user.set_unusable_password()
     user.save()
+    log.info("Created new Edx LTI user: %s", user.username)
     return user
 
 
@@ -120,6 +121,7 @@ class LtiProfileManager(models.Manager):
             except IntegrityError:
                 # In case we get a duplicate username - odds are very low so trying
                 # once more should be sufficient
+                log.warning("Failed to create LTI user due to IntegrityError; retrying")
                 user = create_edx_user(first_name, last_name)
             return self.create(
                 user=user,

--- a/src/lti_1p3_provider/tests/test_auth.py
+++ b/src/lti_1p3_provider/tests/test_auth.py
@@ -25,8 +25,8 @@ class LtiAuthenticationBackendTest(TestCase):
         self.assertIsNone(user)
 
     def test_with_profile(self):
-        profile = LtiProfile.objects.create(
-            platform_id=self.iss, client_id=self.aud, subject_id=self.sub
+        profile = LtiProfile.objects.get_or_create_from_claims(
+            iss=self.iss, aud=self.aud, sub=self.sub
         )
         backend = Lti1p3AuthenticationBackend()
         user = backend.authenticate(None, iss=self.iss, aud=self.aud, sub=self.sub)
@@ -35,11 +35,8 @@ class LtiAuthenticationBackendTest(TestCase):
 
     def test_with_profile_and_email(self):
         """Email is not considered when doing lookups"""
-        profile = LtiProfile.objects.create(
-            platform_id=self.iss,
-            client_id=self.aud,
-            subject_id=self.sub,
-            email=self.email,
+        profile = LtiProfile.objects.get_or_create_from_claims(
+            iss=self.iss, aud=self.aud, sub=self.sub, email=self.email
         )
         backend = Lti1p3AuthenticationBackend()
         user = backend.authenticate(None, iss=self.iss, aud=self.aud, sub=self.sub)
@@ -47,8 +44,8 @@ class LtiAuthenticationBackendTest(TestCase):
         self.assertEqual(user.lti_1p3_provider_lti_profile, profile)
 
     def test_inactive_user_returns_none(self):
-        profile = LtiProfile.objects.create(
-            platform_id=self.iss, client_id=self.aud, subject_id=self.sub
+        profile = LtiProfile.objects.get_or_create_from_claims(
+            iss=self.iss, aud=self.aud, sub=self.sub
         )
         user = profile.user
         user.is_active = False

--- a/src/lti_1p3_provider/tests/test_models.py
+++ b/src/lti_1p3_provider/tests/test_models.py
@@ -64,26 +64,6 @@ class LtiProfileTest(TestCase):
         )
         self.assertEqual(expected_url, profile.subject_url)
 
-    def test_create_with_user(self):
-        """
-        Given a profile without a user
-        When save is called
-        Then a user is created.
-        """
-
-        iss = "http://foo.example.com/"
-        sub = "randomly-selected-sub-for-testing"
-        aud = "randomly-selected-aud-for-testing"
-        with mock.patch(
-            "lti_1p3_provider.models.generate_random_edx_username",
-            return_value="rando-username",
-        ):
-            profile = LtiProfile.objects.create(
-                platform_id=iss, client_id=aud, subject_id=sub
-            )
-        self.assertIsNotNone(profile.user)
-        self.assertEqual(profile.user.username, "rando-username")
-
     def test_get_or_create_from_claims(self):
         """
         Given a profile does not exist


### PR DESCRIPTION
- Stores the `given_name` on `User.first_name` and `family_name` on `User.last_name` if the claims are present in the jwt
- Updates the values if they change from the last time they were launched
- Bumps version to 2.3.2

Closes #30 