### PR TITLE
35 display specific error for missing cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2.3.4
+### Changed
+- [#35](https://github.com/ibleducation/ibl-edx-lti-1p3-provider-app/issues/35): Show user friendly missing session-cookie specific error when lti1p3-session-id is missing
+
 ## 2.3.3
 ### Changed
 - [#32](https://github.com/ibleducation/ibl-edx-lti-1p3-provider-app/issues/32): Update `UserProfile.name` with `{given_name} {family_name}` if present in claims

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="ibl-lti-1p3-provider",
-    version="2.3.3",
+    version="2.3.4",
     packages=find_packages("src"),
     include_package_data=True,
     package_dir={"": "src"},

--- a/src/lti_1p3_provider/error_response.py
+++ b/src/lti_1p3_provider/error_response.py
@@ -3,8 +3,15 @@ from __future__ import annotations
 from typing import Any
 from urllib import parse
 
+from django.conf import settings
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
+
+MISSING_SESSION_COOKIE_ERR_MSG = (
+    "Oops! It looks like you’re using a browser or privacy "
+    "setting that’s blocking third-party cookies. Please try switching to a standard browsing "
+    "window (non-incognito) or adjust your browser settings to allow cookies for this page."
+)
 
 
 class LTIErrorRedirect(HttpResponseRedirect):
@@ -77,6 +84,18 @@ def _get_launch_presentation(launch_data: dict) -> dict:
     return launch_data.get(
         "https://purl.imsglobal.org/spec/lti/claim/launch_presentation", {}
     )
+
+
+def get_contact_support_msg(support_email: str = "") -> str:
+    """Return the 'contact support' error message
+
+    Params:
+        support_email (str): Defaults to settings.CONTACT_EMAIL
+    """
+    support_email = support_email or getattr(
+        settings, "CONTACT_EMAIL", "contact@example.local"
+    )
+    return f"Need more help? Contact our support team at {support_email}."
 
 
 def render_edx_error(


### PR DESCRIPTION
- Adds a specific user error message when the lti 1p3 session cookie is missing, typically due to third party cookies being blocked when launching from an iframe (like incognito by default)
- Bumps version to 2.3.4

Closes #35 