### PR TITLE
37 handle null email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2.3.5
+### Changed
+- [#37](https://github.com/ibleducation/ibl-edx-lti-1p3-provider-app/issues/37): Handle email claim being `null`
+
 ## 2.3.4
 ### Changed
 - [#35](https://github.com/ibleducation/ibl-edx-lti-1p3-provider-app/issues/35): Show user friendly missing session-cookie specific error when lti1p3-session-id is missing

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="ibl-lti-1p3-provider",
-    version="2.3.4",
+    version="2.3.5",
     packages=find_packages("src"),
     include_package_data=True,
     package_dir={"": "src"},

--- a/src/lti_1p3_provider/tests/test_views.py
+++ b/src/lti_1p3_provider/tests/test_views.py
@@ -32,7 +32,7 @@ from lti_1p3_provider.error_response import (
     MISSING_SESSION_COOKIE_ERR_MSG,
     get_contact_support_msg,
 )
-from lti_1p3_provider.models import LtiGradedResource, LtiProfile
+from lti_1p3_provider.models import EDX_LTI_EMAIL_DOMAIN, LtiGradedResource, LtiProfile
 from lti_1p3_provider.session_access import LTI_SESSION_KEY
 from lti_1p3_provider.views import (
     LTI_1P3_EMAIL_META_KEY,
@@ -239,10 +239,7 @@ class TestLtiToolLaunchView:
         assert lti_profile.user.profile.get_meta()[LTI_1P3_EMAIL_META_KEY] == email
 
     def test_successful_launch_with_email_null_is_allowed(self, client):
-        """If email claim provided, sets it in the LtiProfile and UserProfile
-
-        User does not yet exist, so User, LtiProfile, and UserProfile are created
-        """
+        """If email claim is null, it is allowed and the user gets a default email"""
         email = None
         target_link_uri = _get_target_link_uri(
             str(factories.COURSE_KEY), str(factories.USAGE_KEY)
@@ -271,7 +268,7 @@ class TestLtiToolLaunchView:
             iss=id_token["iss"], aud=id_token["aud"], sub=id_token["sub"]
         )
         assert lti_profile.email == ""
-        assert lti_profile.user.profile.get_meta()[LTI_1P3_EMAIL_META_KEY] == email
+        assert lti_profile.user.email.endswith(f"@{EDX_LTI_EMAIL_DOMAIN}")
 
     def test_existing_user_profile_with_no_email_gets_updated(self, client):
         """If email claim provided, updates the existing LtiProfile and UserProfile"""

--- a/src/lti_1p3_provider/views.py
+++ b/src/lti_1p3_provider/views.py
@@ -160,7 +160,7 @@ class LtiToolLaunchView(LtiToolView):
         authenticate the LTI user associated with it.
         """
 
-        email_claim = self.launch_data.get("email", "")
+        email_claim = self.launch_data.get("email", "") or ""  # can't allow null email
         first_name = self.launch_data.get("given_name", "")
         last_name = self.launch_data.get("family_name", "")
         lti_profile = LtiProfile.objects.get_or_create_from_claims(


### PR DESCRIPTION
- handle the case where the email claim is `null` instead of just missing or an empty string
-  bump version to 2.3.5

Closes #37 