### PR TITLE
34 prevent deleting keys until they are unused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2.3.6
+### Changed
+- [#34](https://github.com/ibleducation/ibl-edx-lti-1p3-provider-app/issues/34): Don't allow LtiKey's to be deleted if they are still referenced by an LTITool
+
 ## 2.3.5
 ### Changed
 - [#37](https://github.com/ibleducation/ibl-edx-lti-1p3-provider-app/issues/37): Handle email claim being `null`

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="ibl-lti-1p3-provider",
-    version="2.3.5",
+    version="2.3.6",
     packages=find_packages("src"),
     include_package_data=True,
     package_dir={"": "src"},

--- a/src/lti_1p3_provider/api/tests/test_views.py
+++ b/src/lti_1p3_provider/api/tests/test_views.py
@@ -6,14 +6,15 @@ from typing import Any
 import pytest
 from common.djangoapps.student.tests.factories import UserFactory
 from django.urls import reverse
-from lti_1p3_provider.models import LtiKeyOrg, LtiToolOrg
-from lti_1p3_provider.tests import factories
 from openedx.core.djangoapps.oauth_dispatch.tests.factories import (
     AccessTokenFactory,
     ApplicationFactory,
 )
 from organizations.tests.factories import OrganizationFactory
 from pylti1p3.contrib.django.lti1p3_tool_config.models import LtiTool, LtiToolKey
+
+from lti_1p3_provider.models import LtiKeyOrg, LtiToolOrg
+from lti_1p3_provider.tests import factories
 
 
 @pytest.fixture(autouse=True)
@@ -203,6 +204,25 @@ class TestLtiKeyViews(BaseView):
 
         assert LtiKeyOrg.objects.count() == 0
         assert LtiToolKey.objects.count() == 0
+
+    def test_deleting_key_referened_by_another_tool_returns_400(
+        self, client, admin_token
+    ):
+        """If a key is referenced by another tool it can't be deleted"""
+
+        key_org = factories.LtiKeyOrgFactory()
+        tool = factories.LtiToolFactory(lti_key=key_org.key)
+        org = key_org.org
+        key = key_org.key
+        endpoint = self._get_detail_endpoint(org.short_name, key.pk)
+
+        resp = self.request(client, "delete", endpoint, token=admin_token)
+
+        assert resp.status_code == 400, resp.json()
+        breakpoint()
+
+        assert LtiKeyOrg.objects.count() == 1
+        assert LtiToolKey.objects.count() == 1
 
     def test_delete_key_not_in_target_org_returns_404(self, client, admin_token):
         """Delete removes LtiToolKey and LtiKeyOrg for specified enttiy, returns 204"""


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [ ] API endpoints openapi schema was updated if applicable (*N/A*)

## Changes
- Returns a 400 if you try to delete an LTI Key that's currently referenced by another tool
- Bumps version to 2.3.6
- Closes #34 
