### PR TITLE
45 improve invalid target link uri handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 2.4.1
+### Changed
+- [#45](https://github.com/iblai/ibl-edx-lti-1p3-provider-app/issues/45): Further validate the `target_link_uri` to ensure:
+  - It's domain is our domain (so we don't send the user outside our platform)
+  - It's specifically out `lti-display` endpoint - that's the only place we can go
+  - Return a more specific error if someone sets it to our deep-linking/lti-launch endpoints (common mistakes)
+
 ## 2.4.0
 ### Added
 - [#44](https://github.com/iblai/ibl-edx-lti-1p3-provider-app/issues/44): Adds support for Deep Linking.`ltiResourceLink` is the only supported resource type.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="ibl-lti-1p3-provider",
-    version="2.4.0",
+    version="2.4.1",
     packages=find_packages("src"),
     include_package_data=True,
     package_dir={"": "src"},

--- a/src/lti_1p3_provider/tests/test_views/test_views.py
+++ b/src/lti_1p3_provider/tests/test_views/test_views.py
@@ -43,6 +43,13 @@ from lti_1p3_provider.views import (
 )
 
 
+@pytest.fixture(autouse=True)
+def override_lms_base():
+    """Override LMS_BASE for the duration of the test"""
+    with override_settings(LMS_BASE="localhost"):
+        yield
+
+
 def _get_session_middleware():
     """Get Initialized SessionMiddleware"""
     return SessionMiddleware(lambda r: None)
@@ -754,9 +761,7 @@ class TestLtiBasicLaunch:
         """Error returned via return_url w/ errormsg (when specified)"""
         base = reverse("lti_1p3_provider:lti-launch")
         # Invalid usage key so it will return an error w/ errormsg
-        target_link_uri = (
-            f"{base}{str(factories.COURSE_KEY)}/block-v1:org1+course1+run1"
-        )
+        target_link_uri = f"https://localhost{base}{str(factories.COURSE_KEY)}/block-v1:org1+course1+run1"
         return_url = "https://endpoint.com/return_url?item=123"
         payload = self._get_payload(
             "", "", target_link_uri=target_link_uri, return_url=return_url
@@ -849,6 +854,63 @@ class TestLtiBasicLaunch:
             request.session[LTI_SESSION_KEY][target_link_path_1]
             == link_1_exp.isoformat()
         )
+
+    def test_target_link_uri_does_not_match_lms_domain_returns_400(self, client):
+        """If target_link_uri domain doesn't match LMS_BASE, 400 is returned"""
+        # Create a target_link_uri with a different domain
+        target_link_uri = _get_target_link_uri(
+            str(factories.COURSE_KEY),
+            str(factories.USAGE_KEY),
+            domain="https://different-domain.com",
+        )
+        payload = self._get_payload(
+            factories.COURSE_KEY, factories.USAGE_KEY, target_link_uri=target_link_uri
+        )
+
+        resp = client.post(self.launch_endpoint, payload)
+
+        soup = BeautifulSoup(resp.content, "html.parser")
+        assert soup.find("h1").text == "Invalid LTI Tool Launch"
+        assert soup.find("p").text.startswith(
+            f"Invalid target_link_uri domain: {target_link_uri}"
+        )
+        assert resp.status_code == 400
+
+    @override_settings(LMS_BASE="lms.local")
+    @pytest.mark.parametrize(
+        "endpoint_name,expected_error",
+        [
+            (
+                "deep-link-launch",
+                "Deep Linking Launch endpoint is not a valid target_link_uri for basic launches.",
+            ),
+            (
+                "lti-launch",
+                "LTI Launch endpoint is not a valid target_link_uri for basic launches.",
+            ),
+            (
+                "lti-login",
+                "Invalid target_link_uri: ",
+            ),
+        ],
+    )
+    def test_target_link_uri_does_not_match_lti_display_endpoint_returns_400(
+        self, client, endpoint_name, expected_error
+    ):
+        """If target_link_uri points to wrong endpoint, 400 is returned with specific error"""
+        # Create target_link_uri pointing to the wrong endpoint
+        wrong_endpoint = reverse(f"lti_1p3_provider:{endpoint_name}")
+        target_link_uri = f"http://lms.local{wrong_endpoint}"
+        payload = self._get_payload(
+            factories.COURSE_KEY, factories.USAGE_KEY, target_link_uri=target_link_uri
+        )
+
+        resp = client.post(self.launch_endpoint, payload)
+
+        soup = BeautifulSoup(resp.content, "html.parser")
+        assert soup.find("h1").text == "Invalid LTI Tool Launch"
+        assert expected_error in soup.find("p").text
+        assert resp.status_code == 400
 
 
 @pytest.mark.django_db
@@ -1090,4 +1152,3 @@ class TestDisplayTargetResourceView:
         soup = BeautifulSoup(resp.content, "html.parser")
         assert soup.find("h1").text == "Unauthorized"
         assert resp.status_code == 401
-

--- a/src/lti_1p3_provider/views.py
+++ b/src/lti_1p3_provider/views.py
@@ -19,7 +19,7 @@ from django.http import (
     JsonResponse,
 )
 from django.shortcuts import redirect, render
-from django.urls import Resolver404, resolve, reverse
+from django.urls import Resolver404, ResolverMatch, resolve, reverse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.clickjacking import xframe_options_exempt
@@ -366,24 +366,65 @@ class LtiToolLaunchView(LtiToolView):
                 request, self.launch_data, errormsg=errormsg, status=500
             )
 
-    def _get_course_and_usage_id(self) -> tuple[str, str]:
+    def _get_course_and_usage_id(self, match: ResolverMatch) -> tuple[str, str]:
         """Return course_id and usage_id from target_link_uri string"""
+        return match.kwargs["course_id"], match.kwargs["usage_id"]
+
+    def _validate_target_link_uri(self) -> ResolverMatch:
+        """Validate the target_link_uri and return ResolverMatch if matches lti-display endpoint
+
+        Raises LtiException error on failures
+        """
         target_link_uri = self._get_target_link_uri()
-        path = parse.urlparse(target_link_uri)[2]
+        parts = parse.urlparse(target_link_uri)
+
+        # Ensure target_link_uri is on our platform
+        if parts.netloc != settings.LMS_BASE:
+            log.warning(
+                "Invalid target_link_uri_domain: %s. Must match LMS_BASE",
+                target_link_uri,
+            )
+            raise LtiException(f"Invalid target_link_uri domain: {target_link_uri}")
+
+        # ensure the target_link_uri is the lti-display endpoint; it's the only one we accept
+        path = parts.path
+        log.debug("Target link uri: %s", path)
         try:
-            log.debug("Target link uri: %s", path)
-            match = resolve(path)
+            match = resolve(str(path))
         except Resolver404:
-            log.error("target link uri: %s is invalid", path)
+            log.warning("No resolve match for target link uri: %s", path)
             raise LtiException("Invalid target_link_uri path: %s", path)
 
-        return match.kwargs["course_id"], match.kwargs["usage_id"]
+        if match.url_name != "lti-display":
+            log.warning(
+                "target link uri does not point to lti-display endpoint: uri=%s,"
+                "match.url_name=%s",
+                path,
+                match.url_name,
+            )
+            err_msg = f"Invalid target_link_uri: {path}."
+            err_details = self._get_invalid_target_link_uri_error(match)
+            if err_details:
+                err_msg = f"{err_msg}. {err_details}"
+            raise LtiException(err_msg)
+
+        return match
 
     def _get_target_link_uri(self) -> str | None:
         """Return target link URI from payload"""
         return self.launch_data.get(
             "https://purl.imsglobal.org/spec/lti/claim/target_link_uri"
         )
+
+    def _get_invalid_target_link_uri_error(self, match: ResolverMatch) -> str:
+        """Return a more descriptive error about the endpoint if possible"""
+        if match.url_name == "deep-link-launch":
+            return "Deep Linking Launch endpoint is not a valid target_link_uri for basic launches."
+        if match.url_name == "lti-launch":
+            return (
+                "LTI Launch endpoint is not a valid target_link_uri for basic launches."
+            )
+        return ""
 
     def handle_ags(self, course_key: CourseKey, usage_key: UsageKey) -> None:
         """
@@ -472,8 +513,10 @@ class LtiToolLaunchView(LtiToolView):
         Handle regular LTI resource link launch requests.
         """
         # Regular resource link launch - parse course and usage keys
-        course_id, usage_id = self._get_course_and_usage_id()
-        course_key, usage_key = parse_course_and_usage_keys(course_id, usage_id)
+        match = self._validate_target_link_uri()
+        course_key, usage_key = parse_course_and_usage_keys(
+            match.kwargs["course_id"], match.kwargs["usage_id"]
+        )
         log.info(
             "LTI 1.3: issuer=%s, client_id=%s, Launch course=%s, block: id=%s",
             self.launch_message.get_iss(),


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [ ] API endpoints openapi schema was updated if applicable (N/A)

## Changes
Further validate the `target_link_uri` to ensure: 
- It's domain is our domain (so we don't send the user outside our platform)
- It's specifically out `lti-display` endpoint - that's the only place we can go
- Return a more specific error if someone sets it to our deep-linking/lti-launch endpoints (common mistakes)

Closes #45 
