### PR TITLE
Store launch id in session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # LTI 1.3 Provider
 
 ## Unreleased
+## 2.5.2
+### Changed
+- [#52](https://github.com/iblai/ibl-edx-lti-1p3-provider-app/issues/52): Store the lti-1p3-launch-id from pylti1p3 in the users session
+
 ## 2.5.1
 ### Changed
 - [#50](https://github.com/iblai/ibl-edx-lti-1p3-provider-app/issues/50): Remove the lti data claim during deep linking if not originally sent

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="ibl-lti-1p3-provider",
-    version="2.5.1",
+    version="2.5.2",
     packages=find_packages("src"),
     include_package_data=True,
     package_dir={"": "src"},

--- a/src/lti_1p3_provider/session_access.py
+++ b/src/lti_1p3_provider/session_access.py
@@ -15,6 +15,7 @@ log = logging.getLogger(__name__)
 
 LTI_SESSION_KEY = "lti_access"
 LTI_DEEP_LINKING_SESSION_PREFIX = "lti_deep_link_context_"
+LTI_LAUNCH_ID_KEY = "lti_1p3_launch_id"
 
 
 def set_lti_session_access(
@@ -28,6 +29,12 @@ def set_lti_session_access(
         session[LTI_SESSION_KEY].update(access)
 
     log.debug("LTI Session Set to: %s", session[LTI_SESSION_KEY])
+
+
+def set_lti_session_launch_id(session: SessionBase, launch_id: str) -> None:
+    """Grant access to path until expiration. If None, it's as long as logged in"""
+    session[LTI_LAUNCH_ID_KEY] = launch_id
+    log.debug("Stored launch id: %s", session[LTI_LAUNCH_ID_KEY])
 
 
 def has_lti_session_access(session: SessionBase, path) -> bool:

--- a/src/lti_1p3_provider/views.py
+++ b/src/lti_1p3_provider/views.py
@@ -63,6 +63,7 @@ from .session_access import (
     generate_deep_linking_token,
     has_lti_session_access,
     set_lti_session_access,
+    set_lti_session_launch_id,
     store_deep_linking_context,
     validate_deep_linking_session,
 )
@@ -571,6 +572,9 @@ class LtiToolLaunchView(LtiToolView):
 
         # Set session access for the target resource
         self._set_session_access()
+        set_lti_session_launch_id(
+            self.request.session, self.launch_message.get_launch_id()
+        )
 
         # Redirect to the target content
         return redirect(self._get_target_link_uri())


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [ ] API endpoints openapi schema was updated if applicable

## Changes
* Stores the lti 1p3 launch id in the users session
* Closes #52 
* Bumps version to 2.5.2