### PR TITLE
54 remove dl content items custom claim if unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # LTI 1.3 Provider
 
 ## Unreleased
+
+## 2.5.3
+### Changed
+- [#54](https://github.com/iblai/ibl-edx-lti-1p3-provider-app/issues/54): Remove `custom` claim from Deep Linking ltiResourceLink content items if empty
+  - Fixes Moodle (it fails if the custom claim is an empty dict)
+
 ## 2.5.2
 ### Changed
 - [#52](https://github.com/iblai/ibl-edx-lti-1p3-provider-app/issues/52): Store the lti-1p3-launch-id from pylti1p3 in the users session

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="ibl-lti-1p3-provider",
-    version="2.5.2",
+    version="2.5.3",
     packages=find_packages("src"),
     include_package_data=True,
     package_dir={"": "src"},

--- a/src/lti_1p3_provider/tests/test_views/test_deep_linking_views.py
+++ b/src/lti_1p3_provider/tests/test_views/test_deep_linking_views.py
@@ -684,6 +684,10 @@ class TestDeepLinkingContentSelectionViewPOST(DeepLinkingContentSelectionBaseTes
             f"Expected {dl_data_claim} to be absent from JWT when not in deep_linking_settings"
         )
 
+        # custom claim for lti resource links is removed when unset (default)
+        content_items = "https://purl.imsglobal.org/spec/lti-dl/claim/content_items"
+        assert "custom" not in content_items[0]
+
         # Verify that the deep linking session was cleared
         session_key = f"{LTI_DEEP_LINKING_SESSION_PREFIX}{self.token}"
         assert session_key not in client.session

--- a/src/lti_1p3_provider/tests/test_views/test_deep_linking_views.py
+++ b/src/lti_1p3_provider/tests/test_views/test_deep_linking_views.py
@@ -684,9 +684,15 @@ class TestDeepLinkingContentSelectionViewPOST(DeepLinkingContentSelectionBaseTes
             f"Expected {dl_data_claim} to be absent from JWT when not in deep_linking_settings"
         )
 
-        # custom claim for lti resource links is removed when unset (default)
-        content_items = "https://purl.imsglobal.org/spec/lti-dl/claim/content_items"
-        assert "custom" not in content_items[0]
+        # custom claim for lti resource link content items is removed when unset (default)
+        content_items_claim = (
+            "https://purl.imsglobal.org/spec/lti-dl/claim/content_items"
+        )
+        content_items = decoded[content_items_claim]
+        assert len(content_items) == 1
+        item = content_items[0]
+        assert item["type"] == "ltiResourceLink"
+        assert "custom" not in item
 
         # Verify that the deep linking session was cleared
         session_key = f"{LTI_DEEP_LINKING_SESSION_PREFIX}{self.token}"

--- a/src/lti_1p3_provider/views.py
+++ b/src/lti_1p3_provider/views.py
@@ -1016,12 +1016,7 @@ class DeepLinkingContentSelectionView(LtiToolView):
         # Clear the deep linking session since content has been selected successfully
         clear_deep_linking_session(session=request.session, token=token)
         target_link_uri = self._get_target_link_uri(target_xblock)
-        dl_resource = (
-            DeepLinkResource()
-            .set_url(target_link_uri)
-            .set_title(title)
-            .set_custom_params({"test": "value"})
-        )
+        dl_resource = DeepLinkResource().set_url(target_link_uri).set_title(title)
         resources = [dl_resource]
         deep_link = self.launch_message.get_deep_link()
         jwt_val = self._get_dl_message_jwt(deep_link, resources)

--- a/src/lti_1p3_provider/views.py
+++ b/src/lti_1p3_provider/views.py
@@ -940,6 +940,7 @@ class DeepLinkingContentSelectionView(LtiToolView):
         status = 200
         context = {}
         block_filter = None
+        title = ""
         try:
             dl_content_callable = self.launch_gate.get_dl_content_filter_callable()
             if dl_content_callable:
@@ -1016,6 +1017,7 @@ class DeepLinkingContentSelectionView(LtiToolView):
         clear_deep_linking_session(session=request.session, token=token)
         target_link_uri = self._get_target_link_uri(target_xblock)
         dl_resource = DeepLinkResource().set_url(target_link_uri).set_title(title)
+        dl_resource.set_custom_params({"test": "value"})
         resources = [dl_resource]
         deep_link = self.launch_message.get_deep_link()
         jwt_val = self._get_dl_message_jwt(deep_link, resources)

--- a/src/lti_1p3_provider/views.py
+++ b/src/lti_1p3_provider/views.py
@@ -1016,8 +1016,12 @@ class DeepLinkingContentSelectionView(LtiToolView):
         # Clear the deep linking session since content has been selected successfully
         clear_deep_linking_session(session=request.session, token=token)
         target_link_uri = self._get_target_link_uri(target_xblock)
-        dl_resource = DeepLinkResource().set_url(target_link_uri).set_title(title)
-        dl_resource.set_custom_params({"test": "value"})
+        dl_resource = (
+            DeepLinkResource()
+            .set_url(target_link_uri)
+            .set_title(title)
+            .set_custom_params({"test": "value"})
+        )
         resources = [dl_resource]
         deep_link = self.launch_message.get_deep_link()
         jwt_val = self._get_dl_message_jwt(deep_link, resources)

--- a/src/lti_1p3_provider/views.py
+++ b/src/lti_1p3_provider/views.py
@@ -1097,6 +1097,7 @@ class DeepLinkingContentSelectionView(LtiToolView):
             "https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings"
         )
         message_jwt = deep_link.get_message_jwt(resources)
+        message_jwt = self._remove_custom_claim_if_unset(message_jwt)
         # We know it's already got a deep link settings claim at this point
         dl_settings: dict[str, t.Any] = self.launch_message.get_launch_data()[
             dl_settings_claim
@@ -1115,6 +1116,24 @@ class DeepLinkingContentSelectionView(LtiToolView):
         # The incoming dl settings claim is 'data', the response data claim is the full url
         if "data" not in deep_link_settings:
             message_jwt.pop(dl_data_claim, None)
+        return message_jwt
+
+    def _remove_custom_claim_if_unset(
+        self, message_jwt: dict[str, t.Any]
+    ) -> dict[str, t.Any]:
+        """Remove custom claim if it's not set in ltiResourceLink content items
+
+        This is set to an empty dict by default for pylti1p3 even if not explicitly set.
+        Moodle fails if this is an empty dict.
+        """
+        content_items_claim = (
+            "https://purl.imsglobal.org/spec/lti-dl/claim/content_items"
+        )
+        for item in message_jwt.get(content_items_claim, []):
+            if item["type"] == "ltiResourceLink":
+                custom_params = item.get("custom", {})
+                if not custom_params:
+                    item.pop("custom", None)
         return message_jwt
 
     def _get_selectable_content(self) -> dict[str, list[Content]]:


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [ ] API endpoints openapi schema was updated if applicable

## Changes
- Remove `custom` claim from Deep Linking ltiResourceLink content items if empty
  - Fixes Moodle (it fails if the custom claim is an empty dict)
- Version to 2.5.3
- Closes #54 